### PR TITLE
Moved configuration to the volume as well so that you can start the server twice.

### DIFF
--- a/perforce-server/run.sh
+++ b/perforce-server/run.sh
@@ -5,6 +5,16 @@ set -e
 service crond start
 service rsyslog start
 
+if [ ! -d /data/etc ]; then
+	echo First time installation, copying configuration from /etc/perforce to /data/etc and relinking
+	mkdir -p /data/etc
+	cp -r /etc/perforce/* /data/etc/
+fi 
+
+mv /etc/perforce /etc/perforce.orig
+ln -s /data/etc /etc/perforce	
+
+
 NAME="${NAME:-$HOSTNAME}"
 if [ -z "$P4PASSWD" ]; then
     WARN=1


### PR DESCRIPTION
Seems that if you start a server twice, if borks out in the helix configuration since it recreates them each time. Also, I'm partial for having the configuration text editable surviving restarts of the docker container.