### PR TITLE
Add environment variable to configure case sensitivity

### DIFF
--- a/perforce-server/setup-perforce.sh
+++ b/perforce-server/setup-perforce.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 export NAME="${NAME:-p4depot}"
+export CASE_INSENSITIVE="${CASE_INSENSITIVE:-0}"
 export P4ROOT="${DATAVOLUME}/${NAME}"
 
 if [ ! -d $DATAVOLUME/etc ]; then
@@ -26,7 +27,7 @@ for DIR in $P4ROOT $P4SSLDIR; do
 done
 
 if ! p4dctl list 2>/dev/null | grep -q $NAME; then
-    /opt/perforce/sbin/configure-helix-p4d.sh $NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P "${P4PASSWD}"
+    /opt/perforce/sbin/configure-helix-p4d.sh $NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P "${P4PASSWD}" --case $CASE_INSENSITIVE
 fi
 
 p4dctl start -t p4d $NAME


### PR DESCRIPTION
I needed to disable case sensitivity for my installation, so I added an environment variable called `CASE_INSENSITIVE` which controls this option. The variable is passed to `configure-helix-p4d.sh` which configures the case sensitivity setting for p4d on first boot.

It defaults to 0 if it is not set, which matches the default behavior of p4d (case sensitive by default, on Linux anyways). Setting it to 1 (via docker-compose/envfile) disables case sensitivity.