### PR TITLE
Update logs location in run.sh to fix error.

### DIFF
--- a/perforce-server/run.sh
+++ b/perforce-server/run.sh
@@ -10,4 +10,4 @@ bash -x /usr/local/bin/setup-perforce.sh
 
 sleep 2
 
-exec /usr/bin/tail --pid=$(cat /var/run/p4d.$NAME.pid) -f "$DATAVOLUME/$NAME/log"
+exec /usr/bin/tail --pid=$(cat /var/run/p4d.$NAME.pid) -f "$DATAVOLUME/$NAME/logs/log"


### PR DESCRIPTION
Thanks to @kduda in https://github.com/ambakshi/docker-perforce/issues/9

Before this fix, the perforce-server container was crashing within a few seconds every time I ran it.

```bash
...
***** WARNING: USING DEFAULT PASSWORD ******

/usr/bin/tail: cannot open '/data/p4depot/log' for reading: No such file or directory
/usr/bin/tail: no files remaining
/run.sh exited 1
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
...
```