### PR TITLE
Enable the ability to deploy using unicode server

### DIFF
--- a/perforce-server/run.sh
+++ b/perforce-server/run.sh
@@ -2,7 +2,7 @@
 set -e
 
 export NAME="${NAME:-p4depot}"
-export UNICODE="${UNICODE:0}"
+export UNICODE="${UNICODE:-0}"
 
 bash /usr/local/bin/setup-perforce.sh
 

--- a/perforce-server/run.sh
+++ b/perforce-server/run.sh
@@ -2,7 +2,7 @@
 set -e
 
 export NAME="${NAME:-p4depot}"
-export UNICODE="${UNICODE:-0}"
+export USE_UNICODE="${USE_UNICODE:-0}"
 
 bash /usr/local/bin/setup-perforce.sh
 

--- a/perforce-server/run.sh
+++ b/perforce-server/run.sh
@@ -2,6 +2,7 @@
 set -e
 
 export NAME="${NAME:-p4depot}"
+export UNICODE="${UNICODE:0}"
 
 bash /usr/local/bin/setup-perforce.sh
 

--- a/perforce-server/setup-perforce.sh
+++ b/perforce-server/setup-perforce.sh
@@ -14,6 +14,12 @@ fi
 mv /etc/perforce /etc/perforce.orig
 ln -s $DATAVOLUME/etc /etc/perforce
 
+UNICODE=""
+
+if [ "$USE_UNICODE" = "1" ]; then
+    UNICODE="--unicode"
+fi
+
 if [ -z "$P4PASSWD" ]; then
     P4PASSWD="pass12349ers!"
 fi
@@ -27,7 +33,7 @@ for DIR in $P4ROOT $P4SSLDIR; do
 done
 
 if ! p4dctl list 2>/dev/null | grep -q $NAME; then
-    /opt/perforce/sbin/configure-helix-p4d.sh $NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P "${P4PASSWD}" --case $CASE_INSENSITIVE
+    /opt/perforce/sbin/configure-helix-p4d.sh $NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P "${P4PASSWD}" --case $CASE_INSENSITIVE $UNICODE
 fi
 
 p4dctl start -t p4d $NAME

--- a/perforce-server/setup-perforce.sh
+++ b/perforce-server/setup-perforce.sh
@@ -16,7 +16,7 @@ ln -s $DATAVOLUME/etc /etc/perforce
 
 UNICODE=""
 
-if [ "$USE_UNICODE" = "1" ]; then
+if [ "$USE_UNICODE" == "1" ]; then
     UNICODE="--unicode"
 fi
 


### PR DESCRIPTION
In some cases users will want to configure the unicode server, this enables us to do this by providing an additional enviroment variable.